### PR TITLE
chore: more docs per vm

### DIFF
--- a/CA0/vm1-kafka/README.md
+++ b/CA0/vm1-kafka/README.md
@@ -1,0 +1,35 @@
+# VM1 – Kafka (Bitnami, single-node KRaft)
+
+Summary
+- Runs a single-node Apache Kafka 3.7 (Bitnami image) in KRaft mode.
+- Hosts the topics used by the pipeline: gpu.metrics.v1 and token.usage.v1.
+- Persists broker data to a local Docker volume on the VM.
+
+Configuration
+
+| Category   | Details |
+|------------|---------|
+| Hardware   | Suggested instance: t3.small or t4g.small; ≈2 vCPU, 2–4 GB RAM (4–8 GB prod); ≈20 GB gp3 SSD; no GPU |
+| Software   | Docker + bitnami/kafka:3.7; KRaft (no ZK); healthcheck via kafka-broker-api-versions.sh |
+| Networking | Private IP (example): 10.0.1.197; Ports: 9092/tcp exposed; Controller 9093 internal; Advertised listener: PLAINTEXT://10.0.1.197:9092; Volume: ./data → /bitnami/kafka |
+
+Networking notes
+- Only VM3 (processor) and VM4 (producers) should be allowed to reach 9092.
+- Security groups/UFW should restrict 9092 accordingly; SSH 22 allowed from admin only.
+
+Makefile (brief)
+- setup: Install Docker/Compose if missing and create ./data.
+- up / down / restart / ps / logs / health: Lifecycle and status for the kafka container.
+- topics / list-topics: Idempotently create and list gpu.metrics.v1 and token.usage.v1.
+- send-metric / send-token: One-shot sample producers for quick smoke tests.
+- consume-metric / consume-token: Console consumers for manual verification.
+- wipe: docker compose down -v (removes local volumes).
+
+Key variables
+- KAFKA_BIND_ADDR (default 10.0.1.197) controls the advertised listener in docker-compose.
+- BROKER defaults to ${KAFKA_BIND_ADDR}:9092.
+- TOPIC_METRIC=gpu.metrics.v1, TOPIC_TOKEN=token.usage.v1.
+
+Related files
+- docker-compose.yml: bitnami/kafka:3.7 service, ports, healthcheck, data volume, advertised listeners.
+- config/server.properties: additional server configuration (if used).

--- a/CA0/vm2-mongo/README.md
+++ b/CA0/vm2-mongo/README.md
@@ -1,0 +1,31 @@
+# VM2 – MongoDB (single node)
+
+Summary
+- Stores pipeline data in MongoDB 7.0: gpu_metrics and token_usage collections.
+- Initializes indexes automatically from ./config/init-scripts/indexes.js on first start.
+- Intended to be reachable only from VM3 (processor) on port 27017 within the VPC.
+
+Configuration
+
+| Category   | Details |
+|------------|---------|
+| Hardware   | Suggested instance: t3.small or t4g.small; ≈2 vCPU, 2–4+ GB RAM; ≈30 GB gp3 SSD; no GPU |
+| Software   | Docker + mongo:7.0; healthcheck via mongosh ping; init scripts mounted read-only to /docker-entrypoint-initdb.d |
+| Networking | Private IP (example): 10.0.1.86; Port: 27017/tcp exposed to VPC; Access: allow from VM3 only; Collections: gpu_metrics, token_usage |
+| Volumes    | Named volume mongo_data → /data/db; ./config/init-scripts → /docker-entrypoint-initdb.d:ro |
+
+Makefile (brief)
+- setup: Install Docker/Compose if missing.
+- up / down / down-v / restart / ps / logs: Lifecycle and status.
+- wait / ping: Wait for readiness; run db.adminCommand('ping').
+- init-indexes: Apply indexes.js (idempotent).
+- stats: Print document counts for gpu_metrics and token_usage in DB ca0.
+- shell: Open interactive mongosh in the container.
+- fix-perms: Utility in case of host-dir data usage (not needed with named volume).
+
+Key variables
+- DB=ca0; SERVICE=mongo; MONGO=mongosh.
+
+Related files
+- docker-compose.yml: mongo:7.0 service, port 27017, healthcheck, volumes.
+- config/init-scripts/indexes.js: creates indexes on gpu_metrics and token_usage.

--- a/CA0/vm3-processor/README.md
+++ b/CA0/vm3-processor/README.md
@@ -1,0 +1,39 @@
+# VM3 – Processor (Kafka consumer + FastAPI)
+
+Summary
+- Consumes events from Kafka topics gpu.metrics.v1 and token.usage.v1.
+- Computes simple throughput/cost metrics (cost_per_token using PRICE_PER_HOUR_USD) over a sliding window.
+- Writes documents to MongoDB collections: gpu_metrics and token_usage.
+- Exposes a small HTTP API for health (/health) and a helper endpoint (/gpu/info).
+
+Configuration
+
+| Category   | Details |
+|------------|---------|
+| Hardware   | Suggested instance: t3.micro or t4g.micro; ≈1 vCPU, ~1 GB RAM; ≈10 GB gp3 SSD; no GPU required (can read NVML/SMI if present) |
+| Software   | Docker image built from python:3.12-slim; FastAPI 0.112.2; uvicorn 0.30.6; confluent-kafka 2.5.0; pymongo 4.8.0; runs as non-root UID/GID 10001; healthcheck on /health |
+| Networking | Private IP (example): 10.0.1.112; Inbound: 8080/tcp (optional, admin-only); Outbound: Kafka 10.0.1.197:9092 and MongoDB 10.0.1.86:27017 |
+| Env        | KAFKA_BOOTSTRAP, MONGO_URL, PRICE_PER_HOUR_USD (default 0.85), HOST (0.0.0.0), PORT (8080) |
+| Ports      | 8080:8080 (HTTP) |
+| Volumes    | None (state kept in external systems) |
+
+Networking notes
+- Allow inbound 8080 only from your admin IP for health checks; not required for normal pipeline operation.
+- Ensure security groups/UFW allow VM3 → VM1 (9092) and VM3 → VM2 (27017).
+
+Makefile (brief)
+- setup: Install Docker/Compose if missing; add user to docker group; build image.
+- build / up / down / restart / ps / logs: Lifecycle and status.
+- wait: Poll /health until ready; health: curl /health; curl: curl /gpu/info.
+- doctor: Quick reachability checks to Kafka and Mongo plus local /health.
+
+Key topics & collections
+- Consumes: gpu.metrics.v1, token.usage.v1.
+- Writes to MongoDB DB ca0: collections gpu_metrics and token_usage; indexes auto-created.
+
+Related files
+- docker-compose.yml: service definition, env, ports, healthcheck.
+- Dockerfile: Python base, FastAPI/uvicorn startup, non-root user.
+- .env: default endpoints and PORT/price.
+- app/main.py: consumer loop and HTTP routes.
+- app/requirements.txt: pinned Python dependencies.

--- a/CA0/vm4-producers/README.md
+++ b/CA0/vm4-producers/README.md
@@ -1,0 +1,40 @@
+# VM4 – Producers (Kafka event generators)
+
+Summary
+- Generates synthetic events to Kafka for pipeline testing: GPU metrics and token-usage records.
+- Reads seed GPU metadata from gpu_seed.json; for each batch iteration sends one gpu.metrics.v1 and one token.usage.v1 message.
+- One-shot container by default (exits when done); can be re-run to generate more traffic.
+
+Configuration
+
+| Category   | Details |
+|------------|---------|
+| Hardware   | Suggested instance: t3.micro or t4g.micro; ≈1 vCPU, ~1 GB RAM; ≈10 GB gp3 SSD; no GPU |
+| Software   | Docker image built from python:3.12-slim; confluent-kafka 2.5.0; runs as non-root UID/GID 10001; restart: "no" (one-shot); simple TCP healthcheck to Kafka |
+| Networking | Private IP (example): 10.0.1.85; Outbound only to Kafka at 10.0.1.197:9092; No inbound ports exposed |
+| Env        | KAFKA_BOOTSTRAP (e.g., 10.0.1.197:9092); GPU_SEED (/data/gpu_seed.json); BATCH (default 20); SLEEP_SEC (default 0.5); TOPIC_METRIC (gpu.metrics.v1); TOPIC_TOKEN (token.usage.v1); HOSTNAME (vm4) |
+| Ports      | None |
+| Volumes    | Seed file baked-in: gpu_seed.json → /data/gpu_seed.json (override via GPU_SEED if desired) |
+
+Topics
+- Produces to: gpu.metrics.v1 and token.usage.v1.
+
+Networking notes
+- VM4 requires egress to VM1:9092 only. Lock down inbound traffic (SSH 22 from admin IP only).
+
+Makefile (brief)
+- setup: Install Docker/Compose if missing and build the image.
+- build: Build image.
+- up / run-once: Run the producer until the configured batch completes (container exits when done).
+- logs / ps / down / restart: Standard lifecycle and logs.
+- doctor: Quick TCP reachability check to the configured Kafka bootstrap.
+
+Key variables
+- KAFKA (in Makefile) defaults from .env or falls back to 10.0.1.197:9092 for doctor checks.
+
+Related files
+- docker-compose.yml: one-shot service with env, user, and healthcheck.
+- Dockerfile: Python base, copies producer.py and gpu_seed.json.
+- requirements.txt: confluent-kafka dependency.
+- producer.py: generates and publishes events.
+- gpu_seed.json: seed data used for gpu.metrics.v1 messages.


### PR DESCRIPTION
Summary of changes (chore: more docs per vm)

- Adds/expands per-VM README documentation for the CA0 test cluster to make local deployment and testing easier.
- Files changed
  - CA0/vm1-kafka/README.md (modified)
  - CA0/vm2-mongo/README.md (modified)
  - CA0/vm3-processor/README.md (modified)
  - CA0/vm4-producers/README.md (added)

What’s in the PR (high level)
- Clear, per-VM summaries covering hardware/software recommendations, networking, volumes, and intended access controls.
- Makefile task summaries for common lifecycle and smoke-test commands (setup, up/down, logs, health, doctor).
- Key environment variables, topics, and DB collections called out for quick reference.
- Notes on how to run producers, consumers, and the processor service.

Key details (callouts with snippets)
- Kafka topics used by the pipeline:
  - gpu metrics: `gpu.metrics.v1`
  - token usage: `token.usage.v1`

- Kafka service (Bitnami, KRaft):
  - Image: `bitnami/kafka:3.7`
  - Advertised listener example:
    `PLAINTEXT://10.0.1.197:9092`

- MongoDB service:
  - Image: `mongo:7.0`
  - Init scripts mounted to:
    `/docker-entrypoint-initdb.d` (includes `config/init-scripts/indexes.js`)

- Processor (FastAPI) notable envs:
  - `PRICE_PER_HOUR_USD=0.85` (default)
  - HTTP port: `PORT=8080` (health: `/health`, helper: `/gpu/info`)
  - Service entry: `app/main.py`

- Producers (one-shot generator):
  - Seed file: `/data/gpu_seed.json`
  - Kafka client: `confluent-kafka`
  - Configurable via envs: `KAFKA_BOOTSTRAP`, `BATCH`, `SLEEP_SEC`

Example quick-check commands (from each VM dir)
- Create/list topics (vm1):
  - `make -C CA0/vm1-kafka topics`
- Run a producer one-shot (vm4):
  - `make -C CA0/vm4-producers build && make -C CA0/vm4-producers run-once`
- Check processor health (vm3):
  - `curl http://<VM3_IP>:8080/health`
- Check Mongo stats (vm2):
  - `make -C CA0/vm2-mongo stats`

Notes
- This PR is documentation-only: no application logic changes.
- Focus is on making local / VPC test deployments easier to set up and understand (network rules, volumes, and smoke-test steps are emphasized).