### PR TITLE
feat: add main docs for ca1

### DIFF
--- a/CA1/CA1-step-by-step-guide.md
+++ b/CA1/CA1-step-by-step-guide.md
@@ -1,0 +1,500 @@
+# CA1 – Step‑by‑Step Guide (Terraform + Docker‑First)
+
+This guide turns the CA0 manual topology into repeatable, code‑driven infra with **Terraform** and **cloud‑init** (installing **Docker + Compose** on each VM). It maps exactly to the architecture + sequence PUMLs you finalized.
+
+---
+
+## 0) Prereqs (local)
+- Terraform ≥ 1.6: `terraform -version`
+- AWS CLI v2 configured (`aws sts get-caller-identity` should work)
+- An SSH key in `~/.ssh` (public key path you will pass to Terraform)
+- Optional: PlantUML to render diagrams locally
+
+---
+
+## 1) Repo layout (suggested)
+```
+/ca1
+  /terraform
+    main.tf
+    variables.tf
+    outputs.tf
+    backend.tf            # optional remote state
+    /modules
+      /vpc
+        main.tf
+        variables.tf
+      /security_groups
+        main.tf
+        variables.tf
+      /instances
+        main.tf
+        variables.tf
+        /templates
+          vm1-kafka.cloudinit.tftpl
+          vm2-mongo.cloudinit.tftpl
+          vm3-processor.cloudinit.tftpl
+          vm4-producers.cloudinit.tftpl
+  /diagrams
+    architecture-final.puml
+    provisioning-sequence-final.puml
+  Makefile
+  README.md
+```
+
+> You can reuse the final PUMLs directly (export PNG/SVG with your preferred PlantUML flow).
+
+---
+
+## 2) Root Terraform (minimal working example)
+
+**`terraform/main.tf`**
+```hcl
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2.2"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+module "vpc" {
+  source     = "./modules/vpc"
+  vpc_cidr   = var.vpc_cidr
+  subnet_cidr= var.subnet_cidr
+  name       = var.project_name
+}
+
+module "security_groups" {
+  source     = "./modules/security_groups"
+  vpc_id     = module.vpc.vpc_id
+  my_ip_cidr = var.my_ip_cidr
+  name       = var.project_name
+}
+
+module "instances" {
+  source           = "./modules/instances"
+  subnet_id        = module.vpc.subnet_id
+  sg_ids           = module.security_groups.sg_ids
+  key_name         = var.ssh_key_name
+  instance_type    = var.instance_type
+  project_name     = var.project_name
+
+  # Per‑VM settings
+  price_per_hour_usd = var.price_per_hour_usd
+  kafka_bootstrap    = "10.0.1.10:9092"
+  mongo_url          = "mongodb://10.0.1.11:27017/ca0"
+}
+```
+
+**`terraform/variables.tf`**
+```hcl
+variable "project_name"        { type = string }
+variable "region"              { type = string  default = "us-east-1" }
+variable "vpc_cidr"            { type = string  default = "10.0.0.0/16" }
+variable "subnet_cidr"         { type = string  default = "10.0.1.0/24" }
+variable "my_ip_cidr"          { type = string } # e.g., "AAA.BBB.CCC.DDD/32"
+variable "ssh_key_name"        { type = string }
+variable "instance_type"       { type = string  default = "t3a.medium" }
+variable "price_per_hour_usd"  { type = number  default = 0.85 }
+```
+
+**`terraform/outputs.tf`**
+```hcl
+output "vm_ips" {
+  value = module.instances.private_ips
+}
+```
+
+---
+
+## 3) Modules
+
+### 3.1 VPC (single‑subnet private topology)
+**`modules/vpc/main.tf`**
+```hcl
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  tags = { Name = "${var.name}-vpc" }
+}
+
+resource "aws_subnet" "this" {
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = var.subnet_cidr
+  map_public_ip_on_launch = false
+  tags = { Name = "${var.name}-subnet" }
+}
+
+output "vpc_id"   { value = aws_vpc.this.id }
+output "subnet_id"{ value = aws_subnet.this.id }
+```
+
+**`modules/vpc/variables.tf`**
+```hcl
+variable "vpc_cidr"   { type = string }
+variable "subnet_cidr"{ type = string }
+variable "name"       { type = string }
+```
+
+### 3.2 Security Groups (Kafka, Mongo, Processor, Producers)
+**`modules/security_groups/main.tf`**
+```hcl
+variable "vpc_id"     { type = string }
+variable "my_ip_cidr" { type = string }
+variable "name"       { type = string }
+
+# Base SSH from your IP to all hosts
+resource "aws_security_group" "admin" {
+  name        = "${var.name}-admin"
+  description = "SSH from admin IP"
+  vpc_id      = var.vpc_id
+
+  ingress { from_port = 22 to_port = 22 protocol = "tcp" cidr_blocks = [var.my_ip_cidr] }
+  egress  { from_port = 0  to_port = 0  protocol = "-1" cidr_blocks = ["0.0.0.0/0"] }
+}
+
+resource "aws_security_group" "kafka" {
+  name        = "${var.name}-kafka"
+  description = "Kafka 9092"
+  vpc_id      = var.vpc_id
+
+  egress { from_port = 0 to_port = 0 protocol = "-1" cidr_blocks = ["0.0.0.0/0"] }
+}
+
+resource "aws_security_group" "mongo" {
+  name        = "${var.name}-mongo"
+  description = "Mongo 27017"
+  vpc_id      = var.vpc_id
+
+  egress { from_port = 0 to_port = 0 protocol = "-1" cidr_blocks = ["0.0.0.0/0"] }
+}
+
+resource "aws_security_group" "processor" {
+  name        = "${var.name}-processor"
+  description = "Processor 8080"
+  vpc_id      = var.vpc_id
+
+  ingress { from_port = 8080 to_port = 8080 protocol = "tcp" cidr_blocks = [var.my_ip_cidr] }
+  egress  { from_port = 0    to_port = 0    protocol = "-1" cidr_blocks = ["0.0.0.0/0"] }
+}
+
+resource "aws_security_group" "producers" {
+  name        = "${var.name}-producers"
+  description = "Producers"
+  vpc_id      = var.vpc_id
+
+  egress { from_port = 0 to_port = 0 protocol = "-1" cidr_blocks = ["0.0.0.0/0"] }
+}
+
+# Wire intra‑SG ingress rules
+resource "aws_vpc_security_group_ingress_rule" "kafka_from_processor" {
+  security_group_id = aws_security_group.kafka.id
+  referenced_security_group_id = aws_security_group.processor.id
+  ip_protocol = "tcp"
+  from_port  = 9092
+  to_port    = 9092
+}
+
+resource "aws_vpc_security_group_ingress_rule" "kafka_from_producers" {
+  security_group_id = aws_security_group.kafka.id
+  referenced_security_group_id = aws_security_group.producers.id
+  ip_protocol = "tcp"
+  from_port  = 9092
+  to_port    = 9092
+}
+
+resource "aws_vpc_security_group_ingress_rule" "mongo_from_processor" {
+  security_group_id = aws_security_group.mongo.id
+  referenced_security_group_id = aws_security_group.processor.id
+  ip_protocol = "tcp"
+  from_port  = 27017
+  to_port    = 27017
+}
+
+output "sg_ids" {
+  value = {
+    admin     = aws_security_group.admin.id
+    kafka     = aws_security_group.kafka.id
+    mongo     = aws_security_group.mongo.id
+    processor = aws_security_group.processor.id
+    producers = aws_security_group.producers.id
+  }
+}
+```
+
+### 3.3 Instances (cloud‑init drives Docker/Compose per VM)
+**`modules/instances/variables.tf`**
+```hcl
+variable "subnet_id"         { type = string }
+variable "sg_ids"            { type = map(string) }
+variable "key_name"          { type = string }
+variable "instance_type"     { type = string }
+variable "project_name"      { type = string }
+variable "price_per_hour_usd"{ type = number }
+variable "kafka_bootstrap"   { type = string }
+variable "mongo_url"         { type = string }
+```
+
+**`modules/instances/main.tf`**
+```hcl
+locals {
+  common_tags = { Project = var.project_name }
+}
+
+resource "aws_instance" "vm1_kafka" {
+  ami                         = data.aws_ami.ubuntu.id
+  instance_type               = var.instance_type
+  subnet_id                   = var.subnet_id
+  vpc_security_group_ids      = [var.sg_ids.admin, var.sg_ids.kafka]
+  key_name                    = var.key_name
+  user_data                   = templatefile("${path.module}/templates/vm1-kafka.cloudinit.tftpl", {})
+  tags                        = merge(local.common_tags, { Name = "${var.project_name}-vm1-kafka" })
+}
+
+resource "aws_instance" "vm2_mongo" {
+  ami                    = data.aws_ami.ubuntu.id
+  instance_type          = var.instance_type
+  subnet_id              = var.subnet_id
+  vpc_security_group_ids = [var.sg_ids.admin, var.sg_ids.mongo]
+  key_name               = var.key_name
+  user_data              = templatefile("${path.module}/templates/vm2-mongo.cloudinit.tftpl", {})
+  tags                   = merge(local.common_tags, { Name = "${var.project_name}-vm2-mongo" })
+}
+
+resource "aws_instance" "vm3_processor" {
+  ami                    = data.aws_ami.ubuntu.id
+  instance_type          = var.instance_type
+  subnet_id              = var.subnet_id
+  vpc_security_group_ids = [var.sg_ids.admin, var.sg_ids.processor]
+  key_name               = var.key_name
+  user_data              = templatefile("${path.module}/templates/vm3-processor.cloudinit.tftpl", {
+    PRICE_PER_HOUR_USD = var.price_per_hour_usd
+    KAFKA_BOOTSTRAP    = var.kafka_bootstrap
+    MONGO_URL          = var.mongo_url
+  })
+  tags                   = merge(local.common_tags, { Name = "${var.project_name}-vm3-processor" })
+}
+
+resource "aws_instance" "vm4_producers" {
+  ami                    = data.aws_ami.ubuntu.id
+  instance_type          = var.instance_type
+  subnet_id              = var.subnet_id
+  vpc_security_group_ids = [var.sg_ids.admin, var.sg_ids.producers]
+  key_name               = var.key_name
+  user_data              = templatefile("${path.module}/templates/vm4-producers.cloudinit.tftpl", {
+    KAFKA_BOOTSTRAP = var.kafka_bootstrap
+  })
+  tags                   = merge(local.common_tags, { Name = "${var.project_name}-vm4-producers" })
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-*-24.04-amd64-server-*"]
+  }
+}
+
+output "private_ips" {
+  value = {
+    vm1_kafka    = aws_instance.vm1_kafka.private_ip
+    vm2_mongo    = aws_instance.vm2_mongo.private_ip
+    vm3_processor= aws_instance.vm3_processor.private_ip
+    vm4_producers= aws_instance.vm4_producers.private_ip
+  }
+}
+```
+
+---
+
+## 4) Cloud‑init templates (per VM)
+
+> These install Docker/Compose and bring up each service via an inline `docker-compose.yml`. Replace image tags as needed (or swap for your CA0 Compose folders).
+
+**`vm1-kafka.cloudinit.tftpl`**
+```yaml
+#cloud-config
+package_update: true
+package_upgrade: false
+runcmd:
+  - apt-get update -y
+  - apt-get install -y docker.io docker-compose-plugin
+  - mkdir -p /opt/kafka && cd /opt/kafka
+  - cat > docker-compose.yml <<'YML'
+version: "3.8"
+services:
+  kafka:
+    image: bitnami/kafka:3.7
+    container_name: kafka
+    ports: ["9092:9092"]
+    environment:
+      - KAFKA_ENABLE_KRAFT=yes
+      - KAFKA_CFG_NODE_ID=1
+      - KAFKA_CFG_PROCESS_ROLES=broker,controller
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@localhost:9093
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://0.0.0.0:9092
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+    restart: unless-stopped
+YML
+  - docker compose up -d
+  # Create topics (idempotent)
+  - docker exec kafka kafka-topics.sh --create --if-not-exists --topic gpu.metrics.v1 --bootstrap-server localhost:9092
+  - docker exec kafka kafka-topics.sh --create --if-not-exists --topic token.usage.v1 --bootstrap-server localhost:9092
+```
+
+**`vm2-mongo.cloudinit.tftpl`**
+```yaml
+#cloud-config
+package_update: true
+runcmd:
+  - apt-get update -y
+  - apt-get install -y docker.io docker-compose-plugin
+  - mkdir -p /opt/mongo && cd /opt/mongo
+  - cat > docker-compose.yml <<'YML'
+version: "3.8"
+services:
+  mongo:
+    image: mongo:7
+    container_name: mongo
+    ports: ["27017:27017"]
+    volumes:
+      - mongodata:/data/db
+    restart: unless-stopped
+volumes:
+  mongodata: {}
+YML
+  - docker compose up -d
+```
+
+**`vm3-processor.cloudinit.tftpl`**
+```yaml
+#cloud-config
+package_update: true
+runcmd:
+  - apt-get update -y
+  - apt-get install -y docker.io docker-compose-plugin
+  - mkdir -p /opt/processor && cd /opt/processor
+  - cat > .env <<'ENV'
+PRICE_PER_HOUR_USD=${PRICE_PER_HOUR_USD}
+KAFKA_BOOTSTRAP=${KAFKA_BOOTSTRAP}
+MONGO_URL=${MONGO_URL}
+GPU_METRICS_SOURCE=seed
+ENV
+  - cat > docker-compose.yml <<'YML'
+version: "3.8"
+services:
+  app:
+    image: ghcr.io/yourorg/processor:latest
+    container_name: processor
+    env_file: .env
+    ports: ["8080:8080"]
+    restart: unless-stopped
+YML
+  - docker compose up -d
+```
+
+**`vm4-producers.cloudinit.tftpl`**
+```yaml
+#cloud-config
+package_update: true
+runcmd:
+  - apt-get update -y
+  - apt-get install -y docker.io docker-compose-plugin
+  - mkdir -p /opt/producers && cd /opt/producers
+  - cat > .env <<'ENV'
+KAFKA_BOOTSTRAP=${KAFKA_BOOTSTRAP}
+ENV
+  - cat > docker-compose.yml <<'YML'
+version: "3.8"
+services:
+  producers:
+    image: ghcr.io/yourorg/producers:latest
+    container_name: producers
+    env_file: .env
+    restart: unless-stopped
+YML
+  - docker compose up -d
+```
+
+---
+
+## 5) Makefile helpers (optional)
+**`Makefile`**
+```makefile
+TF=cd terraform && terraform
+
+deploy:
+	$(TF) init
+	$(TF) plan -var "project_name=ca1" -var "my_ip_cidr=$$(curl -s ifconfig.me)/32" -out tfplan
+	$(TF) apply tfplan
+
+test:
+	@echo "Health check (processor)"; \
+	PROC_IP=$$($(TF) output -raw vm_ips | jq -r '.vm3_processor'); \
+	echo "Processor IP: $$PROC_IP"; \
+	curl -s --connect-timeout 3 http://$$PROC_IP:8080/health || true
+
+destroy:
+	$(TF) destroy -auto-approve
+```
+
+> For private‑only subnets, you’ll run health checks via **SSH port‑forwarding** or a bastion. Adjust SGs/NAT/bastion if you need public reachability.
+
+---
+
+## 6) Apply & Verify
+```bash
+cd terraform
+terraform init
+terraform plan -var="project_name=ca1" -var="my_ip_cidr=AAA.BBB.CCC.DDD/32" -out=tfplan
+terraform apply tfplan
+terraform output
+# Kafka topics (on VM1 via SSH + docker)
+# Mongo check (on VM2) or from VM3 app logs
+# Processor: curl /health (direct, or via SSH tunnel)
+```
+
+**Expected runtime flows**
+- VM4 → VM1: produce `gpu.metrics.v1`, `token.usage.v1` (9092)
+- VM3 → VM1: consume (9092)
+- VM3 → VM2: persist to MongoDB (27017)
+- Admin → VM3: `/health` (8080)
+
+---
+
+## 7) Troubleshooting
+- **Kafka topics missing** → ensure topic create commands ran; re‑run on VM1: `docker exec kafka kafka-topics.sh ...`
+- **Processor can’t reach Kafka/Mongo** → verify SG rules and env in `/opt/processor/.env`
+- **cloud‑init didn’t run** → check `/var/log/cloud-init-output.log` on each VM
+- **Private‑only subnet** → use SSH tunnel or add NAT/bastion as needed
+
+---
+
+## 8) Teardown
+```bash
+cd terraform
+terraform destroy -auto-approve
+```
+
+---
+
+## 9) Diagrams
+- `/diagrams/architecture-final.puml` → export to PNG/SVG
+- `/diagrams/provisioning-sequence-final.puml` → export to PNG/SVG
+
+Keep these in the repo so reviewers can map code ↔ architecture easily.

--- a/CA1/ca1-readme.md
+++ b/CA1/ca1-readme.md
@@ -1,0 +1,50 @@
+# CA1 – Terraform + Docker-First Implementation (mirrors CA0 pipeline)
+
+**Goal:** Provision the CA0 topology with Terraform, and bootstrap each VM to run services via **Docker Compose** (matching the CA0 VM guides).
+
+## Parity Targets (from CA0)
+- **Kafka 3.7.0 (KRaft)** on **VM1**; topics: `gpu.metrics.v1`, `token.usage.v1`  
+- **MongoDB 7.0.x** on **VM2**; DB: `ca0`, collections: `gpu_metrics`, `token_usage`  
+- **FastAPI 0.112 + Uvicorn 0.30** on **VM3**; `/health` on `:8080`; ENV includes `PRICE_PER_HOUR_USD=0.85`  
+- **Producers** (Python 3.12 + confluent-kafka 2.5) on **VM4**; emit GPU + token events  
+
+## Security Groups (ingress)
+- **VM1 kafka**: `9092` from `sg-processor` + `sg-producers`; `22` from Admin IP  
+- **VM2 mongo**: `27017` from `sg-processor`; `22` from Admin IP  
+- **VM3 processor**: `8080` from Admin IP; `22` from Admin IP  
+- **VM4 producers**: `22` from Admin IP  
+
+## Bootstrap Strategy (user-data)
+- Install **Docker** and **Compose plugin** on all VMs  
+- Checkout/pull the repo folders: `CA0/vm1-kafka`, `vm2-mongo`, `vm3-processor`, `vm4-producers`  
+- `docker compose up -d` on each VM  
+- Create Kafka topics on VM1  
+- Write `.env` for VM3 with:
+  ```
+  KAFKA_BOOTSTRAP=10.0.1.10:9092
+  MONGO_URL=mongodb://10.0.1.11:27017/ca0
+  PRICE_PER_HOUR_USD=0.85
+  GPU_METRICS_SOURCE=seed
+  ```
+- Optionally configure a **systemd timer/cron** for VM4 producers
+
+## Minimal Terraform Flow
+```bash
+terraform init
+terraform plan -var="your_ip_cidr=AAA.BBB.CCC.DDD/32" -out=tfplan
+terraform apply tfplan
+terraform output
+curl http://<vm3_private_or_public>:8080/health
+# Teardown when done
+terraform destroy
+```
+
+## Diagrams
+- Architecture: `ca1-architecture.puml`
+- Provisioning Sequence: `ca1-provisioning-sequence.puml`
+
+## Notes
+- If you prefer native installs (no Docker) for Kafka or others, keep ports, topics, and ENV the same; CA1 IaC remains identical.
+- Mirror SG intent with UFW on hosts for defense-in-depth.
+
+**Sources informing versions/flow:** CA0 README (versions, topics, envs), AWS VM setup with Docker-Compose, and setup instructions. See course docs for exact steps.

--- a/CA1/diagrams/architecture-final.puml
+++ b/CA1/diagrams/architecture-final.puml
@@ -1,0 +1,91 @@
+@startuml
+title CA1 – Terraform + Docker-First Architecture (Parity with CA0 pipeline)
+
+skinparam shadowing false
+skinparam componentStyle rectangle
+skinparam wrapWidth 220
+skinparam defaultTextAlignment left
+skinparam nodesep 35
+skinparam ranksep 25
+skinparam ArrowColor #444444
+skinparam ArrowThickness 1.1
+
+legend left
+== Legend ==
+<<tf>> Terraform-managed resource
+<<docker>> Docker/Compose-managed service(s)
+Solid arrows = runtime data flow
+Dashed arrows = IaC/bootstrap/user-data
+end legend
+
+actor "Engineer (Admin IP)" as Admin
+
+package "Terraform Project" {
+  rectangle "module.vpc" as MOD_VPC <<tf>>
+  rectangle "module.security_groups" as MOD_SG <<tf>>
+  rectangle "module.instances" as MOD_INST <<tf>>
+  rectangle "remote state (optional)" as MOD_STATE
+}
+
+node "AWS (us-east-1)" as AWS {
+  frame "VPC 10.0.0.0/16 | Subnet 10.0.1.0/24" as VPC {
+    node "VM1 kafka\n10.0.1.10" as VM1 {
+      component "Kafka 3.7.0 (KRaft)\nPorts: 9092\nTopics:\n- gpu.metrics.v1\n- token.usage.v1" as KAFKA <<docker>>
+    }
+    node "VM2 mongodb\n10.0.1.11" as VM2 {
+      database "MongoDB 7.0.x\nDB: ca0\nCollections:\n- gpu_metrics\n- token_usage" as MONGO <<docker>>
+    }
+    node "VM3 processor\n10.0.1.12" as VM3 {
+      component "FastAPI 0.112 + Uvicorn 0.30\n/health :8080\nENV:\n- KAFKA_BOOTSTRAP=10.0.1.10:9092\n- MONGO_URL=mongodb://10.0.1.11:27017/ca0\n- PRICE_PER_HOUR_USD=0.85\n- GPU_METRICS_SOURCE=seed" as PROCESSOR <<docker>>
+    }
+    node "VM4 producers\n10.0.1.13" as VM4 {
+      component "Python 3.12 + confluent-kafka 2.5\nEmits:\n- gpu.metrics.v1\n- token.usage.v1" as PRODUCERS <<docker>>
+    }
+  }
+
+  rectangle "sg-kafka" as SGK <<tf>>
+  rectangle "sg-mongo" as SGM <<tf>>
+  rectangle "sg-processor" as SGP <<tf>>
+  rectangle "sg-producers" as SGPR <<tf>>
+}
+
+' Terraform relationships
+MOD_VPC --> VPC
+MOD_SG --> SGK
+MOD_SG --> SGM
+MOD_SG --> SGP
+MOD_SG --> SGPR
+MOD_INST --> VM1
+MOD_INST --> VM2
+MOD_INST --> VM3
+MOD_INST --> VM4
+
+' Security group intents (ingress)
+SGPR -[#grey,dashed]-> VM4 : SSH 22 from Admin IP
+SGP  -[#grey,dashed]-> VM3 : 8080 from Admin IP\n22 from Admin IP
+SGM  -[#grey,dashed]-> VM2 : 27017 from sg-processor\n22 from Admin IP
+SGK  -[#grey,dashed]-> VM1 : 9092 from sg-processor + sg-producers\n22 from Admin IP
+
+' Data flow (runtime)
+PRODUCERS --> KAFKA : Produce token/gpu events :9092
+PROCESSOR --> KAFKA : Consume topics :9092
+PROCESSOR --> MONGO : Persist gpu_metrics + token_usage :27017
+Admin --> PROCESSOR : GET /health :8080
+
+' Bootstrap
+cloud "user-data (cloud-init)\n- Install Docker + Compose\n- Fetch repo CA0/VM folders\n- docker compose up -d per VM\n- Write .env files\n- Create topics (VM1)\n- Optional: UFW mirror SGs" as UD
+MOD_INST ..> UD
+UD ..> VM1
+UD ..> VM2
+UD ..> VM3
+UD ..> VM4
+
+note bottom of VM1
+Kafka 3.7.0 (Scala 2.13)\nKRaft mode (no ZooKeeper)\nadvertised.listeners=PLAINTEXT://10.0.1.10:9092
+end note
+
+note bottom of VM2
+MongoDB 7.0.x\nOptional indexes: ca0.gpu_metrics(ts:1)
+end note
+
+@enduml

--- a/CA1/diagrams/provisioning-sequence-final.puml
+++ b/CA1/diagrams/provisioning-sequence-final.puml
@@ -1,0 +1,46 @@
+@startuml
+title CA1 – Terraform Apply → Docker Compose Bootstrap (Per VM)
+
+skinparam shadowing false
+skinparam monochrome true
+skinparam ArrowColor #444444
+skinparam ArrowThickness 1.1
+skinparam wrapWidth 200
+skinparam maxMessageSize 180
+
+actor Engineer as E
+participant "Terraform CLI" as TF
+participant "AWS API" as AWS
+participant "EC2 VM1\nkafka" as VM1
+participant "EC2 VM2\nmongodb" as VM2
+participant "EC2 VM3\nprocessor" as VM3
+participant "EC2 VM4\nproducers" as VM4
+
+E -> TF: terraform init
+E -> TF: terraform plan (VPC, SGs, 4 EC2s, user-data)
+E -> TF: terraform apply -auto-approve
+TF -> AWS: Create VPC/Subnet/Routes
+TF -> AWS: Create SGs (kafka/mongo/processor/producers)
+TF -> AWS: Launch EC2 (VM1..VM4) with user-data (cloud-init)
+
+AWS -> VM1: Execute user-data (Docker + Compose; fetch CA0/vm1-kafka)
+VM1 -> VM1: docker compose up -d (Kafka 3.7.0 KRaft)\nCreate topics: gpu.metrics.v1, token.usage.v1
+
+AWS -> VM2: Execute user-data (Docker + Compose; fetch CA0/vm2-mongo)
+VM2 -> VM2: docker compose up -d (MongoDB 7.0.x)\nInit DB ca0 + optional indexes
+
+AWS -> VM3: Execute user-data (Docker + Compose; fetch CA0/vm3-processor)
+VM3 -> VM3: docker compose up -d (FastAPI/Uvicorn :8080)\nENV: KAFKA_BOOTSTRAP, MONGO_URL, PRICE_PER_HOUR_USD
+
+AWS -> VM4: Execute user-data (Docker + Compose; fetch CA0/vm4-producers)
+VM4 -> VM4: docker compose up -d (Python producer(s))\nTimer/cron optional for periodic emits
+
+VM4 -> VM1: Produce to :9092 (two topics)
+VM3 -> VM1: Consume from :9092
+VM3 -> VM2: Write to :27017
+E -> VM3: curl http://<vm3>:8080/health => 200 OK
+E -> TF: terraform output (IPs, URIs)
+
+E -> TF: terraform destroy (teardown)
+
+@enduml


### PR DESCRIPTION

This pull request introduces comprehensive documentation and diagrams for the CA1 infrastructure-as-code (IaC) implementation, which provisions the CA0 pipeline using Terraform and Docker Compose. The changes add a detailed README describing the architecture, security, and bootstrap strategy; update the architecture overview to include multiple PlantUML diagrams; and provide finalized PlantUML files for both the architecture and provisioning sequence.

**Documentation and Architecture Updates:**

* Added a new `ca1-readme.md` that details the CA1 Terraform + Docker Compose implementation, including parity with CA0, security groups, bootstrap/user-data strategy, and minimal Terraform usage flow.
* Updated `architecture.md` to replace the single PlantUML diagram with three high-level diagrams: architecture, sequence, and overview, each rendered via PlantUML and referenced by URL.

**Diagrams:**

* Added `architecture-final.puml`, a PlantUML diagram illustrating the full CA1 architecture, including VPC, security groups, EC2 instances, Docker-managed services, and bootstrap flow.
* Added `provisioning-sequence-final.puml`, a PlantUML sequence diagram showing the step-by-step provisioning and bootstrap process from Terraform apply to Docker Compose startup on each VM.