### PR TITLE
feat: connect to aws via terraform

### DIFF
--- a/CA1/terraform/main.tf
+++ b/CA1/terraform/main.tf
@@ -1,0 +1,2 @@
+data "aws_caller_identity" "me" {}
+data "aws_region" "current" {}

--- a/CA1/terraform/outputs.tf
+++ b/CA1/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "account_id" {
+  value = data.aws_caller_identity.me.account_id
+}
+output "arn" {
+  value = data.aws_caller_identity.me.arn
+}
+output "region" {
+  value = data.aws_region.current.name
+}

--- a/CA1/terraform/providers.tf
+++ b/CA1/terraform/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region  = var.aws_region
+  profile = var.aws_profile
+}

--- a/CA1/terraform/variables.tf
+++ b/CA1/terraform/variables.tf
@@ -1,0 +1,9 @@
+variable "aws_region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "aws_profile" {
+  type    = string
+  default = "terraform"
+}


### PR DESCRIPTION
This pull request sets up the foundational configuration for using Terraform with AWS in the `CA1/terraform` directory. It introduces provider configuration, essential input variables, and outputs for key AWS account information.

Terraform provider and configuration setup:

* Added a `terraform` block specifying the required Terraform version and the AWS provider version, and configured the AWS provider to use variables for region and profile. (`providers.tf`)

Input variables:

* Introduced `aws_region` and `aws_profile` variables with default values for flexible provider configuration. (`variables.tf`)

AWS account data and outputs:

* Added data sources to fetch the current AWS account identity and region. (`main.tf`)
* Created outputs for `account_id`, `arn`, and `region` to expose this AWS account information after applying the configuration. (`outputs.tf`)